### PR TITLE
add a way to get user-provided label values

### DIFF
--- a/testdata/metadatav4-response-container.json
+++ b/testdata/metadatav4-response-container.json
@@ -9,7 +9,8 @@
         "com.amazonaws.ecs.container-name": "curl",
         "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:111122223333:task/default/8f03e41243824aea923aca126495f665",
         "com.amazonaws.ecs.task-definition-family": "curltest",
-        "com.amazonaws.ecs.task-definition-version": "24"
+        "com.amazonaws.ecs.task-definition-version": "24",
+        "org.opencontainers.image.revision": "0xdeadbeaf"
     },
     "DesiredStatus": "RUNNING",
     "KnownStatus": "RUNNING",

--- a/testdata/metadatav4-response-task.json
+++ b/testdata/metadatav4-response-task.json
@@ -57,7 +57,8 @@
                 "com.amazonaws.ecs.container-name": "curl",
                 "com.amazonaws.ecs.task-arn": "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c",
                 "com.amazonaws.ecs.task-definition-family": "curltest",
-                "com.amazonaws.ecs.task-definition-version": "26"
+                "com.amazonaws.ecs.task-definition-version": "26",
+                "org.opencontainers.image.revision": "0xdeadbeaf"
             },
             "DesiredStatus": "RUNNING",
             "KnownStatus": "RUNNING",

--- a/v4.go
+++ b/v4.go
@@ -13,6 +13,12 @@ import (
 
 const (
 	ecsMetadataUriEnvV4 = "ECS_CONTAINER_METADATA_URI_V4"
+
+	labelEcsCluster               = "com.amazonaws.ecs.cluster"
+	labelEcsContainerName         = "com.amazonaws.ecs.container-name"
+	labelEcsTaskArn               = "com.amazonaws.ecs.task-arn"
+	labelEcsTaskDefinitionFamily  = "com.amazonaws.ecs.task-definition-family"
+	labelEcsTaskDefinitionVersion = "com.amazonaws.ecs.task-definition-version"
 )
 
 type Limits struct {
@@ -20,19 +26,54 @@ type Limits struct {
 	Memory int     `json:"Memory"`
 }
 
+type LabelsV4 struct {
+	EcsCluster               string
+	EcsContainerName         string
+	EcsTaskArn               string
+	EcsTaskDefinitionFamily  string
+	EcsTaskDefinitionVersion string
+
+	rest map[string]string
+}
+
+func (l LabelsV4) Get(name string) string {
+	return l.rest[name]
+}
+
+func (l *LabelsV4) UnmarshalJSON(b []byte) error {
+	if err := json.Unmarshal(b, &l.rest); err != nil {
+		return err
+	}
+	if cluster, ok := l.rest[labelEcsCluster]; ok {
+		l.EcsCluster = cluster
+		delete(l.rest, labelEcsCluster)
+	}
+	if containerName, ok := l.rest[labelEcsContainerName]; ok {
+		l.EcsContainerName = containerName
+		delete(l.rest, labelEcsContainerName)
+	}
+	if taskArn, ok := l.rest[labelEcsTaskArn]; ok {
+		l.EcsTaskArn = taskArn
+		delete(l.rest, labelEcsTaskArn)
+	}
+	if family, ok := l.rest[labelEcsTaskDefinitionFamily]; ok {
+		l.EcsTaskDefinitionFamily = family
+		delete(l.rest, labelEcsTaskDefinitionFamily)
+	}
+	if version, ok := l.rest[labelEcsTaskDefinitionVersion]; ok {
+		l.EcsTaskDefinitionVersion = version
+		delete(l.rest, labelEcsTaskDefinitionVersion)
+	}
+	return nil
+}
+
 type ContainerMetadataV4 struct {
-	DockerID   string `json:"DockerId"`
-	Name       string `json:"Name"`
-	DockerName string `json:"DockerName"`
-	Image      string `json:"Image"`
-	ImageID    string `json:"ImageID"`
-	Labels     struct {
-		EcsCluster               string `json:"com.amazonaws.ecs.cluster"`
-		EcsContainerName         string `json:"com.amazonaws.ecs.container-name"`
-		EcsTaskArn               string `json:"com.amazonaws.ecs.task-arn"`
-		EcsTaskDefinitionFamily  string `json:"com.amazonaws.ecs.task-definition-family"`
-		EcsTaskDefinitionVersion string `json:"com.amazonaws.ecs.task-definition-version"`
-	} `json:"Labels"`
+	DockerID      string    `json:"DockerId"`
+	Name          string    `json:"Name"`
+	DockerName    string    `json:"DockerName"`
+	Image         string    `json:"Image"`
+	ImageID       string    `json:"ImageID"`
+	Labels        LabelsV4  `json:"Labels"`
 	DesiredStatus string    `json:"DesiredStatus"`
 	KnownStatus   string    `json:"KnownStatus"`
 	Limits        Limits    `json:"Limits"`

--- a/v4_test.go
+++ b/v4_test.go
@@ -21,6 +21,8 @@ func TestParseContainerMetadataV4(t *testing.T) {
 	assert.Equal(t, "us-west-2", containerMetadata.LogOptions.AwsRegion)
 	assert.Equal(t, "true", containerMetadata.LogOptions.AwsLogsCreateGroup)
 	assert.Equal(t, "arn:aws:ecs:us-west-2:111122223333:task/default/8f03e41243824aea923aca126495f665", containerMetadata.Labels.EcsTaskArn)
+	assert.Equal(t, "0xdeadbeaf", containerMetadata.Labels.Get("org.opencontainers.image.revision"))
+	assert.Equal(t, "", containerMetadata.Labels.Get("internal.not-exist-label"))
 }
 
 func TestParseTaskMetadataV4(t *testing.T) {
@@ -36,4 +38,6 @@ func TestParseTaskMetadataV4(t *testing.T) {
 	assert.Equal(t, "us-west-2", taskMetadata.Containers[1].LogOptions.AwsRegion)
 	assert.Equal(t, "true", taskMetadata.Containers[1].LogOptions.AwsLogsCreateGroup)
 	assert.Equal(t, "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c", taskMetadata.Containers[1].Labels.EcsTaskArn)
+	assert.Equal(t, "0xdeadbeaf", taskMetadata.Containers[1].Labels.Get("org.opencontainers.image.revision"))
+	assert.Equal(t, "", taskMetadata.Containers[1].Labels.Get("internal.not-exist-label"))
 }

--- a/v4_test.go
+++ b/v4_test.go
@@ -20,6 +20,7 @@ func TestParseContainerMetadataV4(t *testing.T) {
 	assert.Equal(t, "ecs/curl/8f03e41243824aea923aca126495f665", containerMetadata.LogOptions.AwsLogsStream)
 	assert.Equal(t, "us-west-2", containerMetadata.LogOptions.AwsRegion)
 	assert.Equal(t, "true", containerMetadata.LogOptions.AwsLogsCreateGroup)
+	assert.Equal(t, "arn:aws:ecs:us-west-2:111122223333:task/default/8f03e41243824aea923aca126495f665", containerMetadata.Labels.EcsTaskArn)
 }
 
 func TestParseTaskMetadataV4(t *testing.T) {
@@ -34,4 +35,5 @@ func TestParseTaskMetadataV4(t *testing.T) {
 	assert.Equal(t, "ecs/curl/158d1c8083dd49d6b527399fd6414f5c", taskMetadata.Containers[1].LogOptions.AwsLogsStream)
 	assert.Equal(t, "us-west-2", taskMetadata.Containers[1].LogOptions.AwsRegion)
 	assert.Equal(t, "true", taskMetadata.Containers[1].LogOptions.AwsLogsCreateGroup)
+	assert.Equal(t, "arn:aws:ecs:us-west-2:111122223333:task/default/158d1c8083dd49d6b527399fd6414f5c", taskMetadata.Containers[1].Labels.EcsTaskArn)
 }


### PR DESCRIPTION
# issue

ECS allows the user to add custom labels, but this library unmarshals the `Labels` field into the struct that has only ECS-provided labels.

So currently we don't have a way to get user-provided label values.

# solution

- add `LabelV4` struct that has the same fields as the previous struct type
  - almost keep backward compatibility
- add the `LabelV4.Get()` method that a way to get user-provided labels
  - `LabelV4.UnmarshalJSON()` unmarshals rest of labels into private `rest` field and `LabelV4.Get()` uses that field

